### PR TITLE
Added B option to RewriteRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Use an `.htaccess` file for mod_rewrite (if you're using Apache)
       # Reroute any incoming requestst that is not an existing directory or file
       RewriteCond %{REQUEST_FILENAME} !-d
       RewriteCond %{REQUEST_FILENAME} !-f
-      RewriteRule ^(.*)$ index.php?u=$1 [L,QSA]
+      RewriteRule ^(.*)$ index.php?u=$1 [L,QSA,B]
     </IfModule>
 
 


### PR DESCRIPTION
If the query string includes a properly escaped # (%23) then apache won't properly deal with that during the RewriteRule, so you have to add the B option, per http://stackoverflow.com/questions/9384796/apache-rewriting-eats-one-level-of-escaping-23 and http://httpd.apache.org/docs/current/rewrite/flags.html#flag_b . Without this option, in the url: url.com/%23none+of+this+shows+up.
