### PR TITLE
Handle JSON requests with spaces and dots

### DIFF
--- a/src/Bullet/Request.php
+++ b/src/Bullet/Request.php
@@ -130,8 +130,10 @@ class Request
             parse_str($raw, $params);
 
             // Check to ensure raw body was decoded correctly. If it wasn't, the whole raw string will be a key in the
-            // resulting array instead of something sensible, like... I dunno... boolean false, maybe? (f#*@&! php)
-            if(isset($params[$raw])) {
+            // resulting array instead of something sensible, like... I dunno... boolean false, maybe? (f#*@&! php).
+            // Additionally, parse_str will convert spaces and dots to underscores so we have to watch for that.
+            $raw_transformed = str_replace(array(" ", "."), "_", $raw);
+            if(isset($params[$raw_transformed])) {
                 $params = array();
                 $json = json_decode($raw, true);
                 if($json) {

--- a/tests/Bullet/Tests/RequestTest.php
+++ b/tests/Bullet/Tests/RequestTest.php
@@ -115,6 +115,42 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $r->post('foo'));
     }
 
+    function testRawJsonBodyWithSpacesInValueIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo":"bar baz"}');
+        $this->assertEquals('bar baz', $r->foo);
+    }
+
+    function testRawJsonBodyWithSpacesInKeyIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"baz"}');
+        $this->assertEquals('baz', $r->{'foo bar'});
+    }
+
+    function testRawJsonBodyWithSpacesInKeyAndValueIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"bar baz"}');
+        $this->assertEquals('bar baz', $r->{'foo bar'});
+    }
+
+    function testRawJsonBodyWithDotsInValueIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"link":"http://bulletphp.com/"}');
+        $this->assertEquals('http://bulletphp.com/', $r->link);
+    }
+
+    function testRawJsonBodyWithDotsInKeyIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"bulletphp"}');
+        $this->assertEquals('bulletphp', $r->{'the.link'});
+    }
+
+    function testRawJsonBodyWithDotsInKeyAndValueIsDecodedInPutRequest()
+    {
+        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"http://bulletphp.com"}');
+        $this->assertEquals('http://bulletphp.com', $r->{'the.link'});
+    }
+
     function testSubdomainCapture()
     {
         $r = new Bullet\Request('GET', '/', array(), array('Host' => 'test.bulletphp.com'));


### PR DESCRIPTION
As suggested in the [docs on php.net](http://us3.php.net/manual/en/function.parse-str.php#43317) `parse_str` will convert spaces and dots to underscores. The workaround already in place in bullet needs a little tweaking when you send a request like:

``` json
{
    "link" : "http://www.google.com"
}
```

Because the current resulting `$params` from `parse_str` will look like something this:

```
Array
(
    [{"link":"http://www_google_com"}] => ""
)
```

The result is that we don't detect this situation and don't parse the body into the request object.
