### PR TITLE
Domain/subdomain handlers no longer return 200

### DIFF
--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -250,17 +250,17 @@ class App extends \Pimple
             $res = call_user_func($cb, $request);
         }
 
+        // Return false for subdomain and domain by default
+        if($res === null) {
+            $res = false;
+        }
+
         // Run 'path' callbacks
         if(isset($this->_callbacks['path'][self::$_pathLevel][$path])) {
             $cb = $this->_callbacks['path'][self::$_pathLevel][$path];
             self::$_pathLevel++;
             $res = call_user_func($cb, $request);
             $pathMatched = true;
-
-            // Ensure no other paths are parsed after full match is made
-            if($this->isRequestPath()) {
-                $this->resetCallbacks('param');
-            }
         }
 
         // Run 'param' callbacks
@@ -306,7 +306,6 @@ class App extends \Pimple
                 $cb = $this->_callbacks['method'][self::$_pathLevel][$method];
                 self::$_pathLevel++;
                 $res = call_user_func($cb, $request);
-                $this->resetCallbacks(array('param', 'path'));
             } else {
                 $res = $this->response(405);
             }

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1058,6 +1058,24 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(404, $result->status());
     }
 
+    public function testDomainRoute404OnRequestedDomain()
+    {
+        $app = new Bullet\App();
+        $app->domain('example.com', function($request) use($app) {
+            $app->path('/goodpath', function($request) use($app) {
+                $app->get(function($request) {
+                    return "GET " . $request->host();
+                });
+            });
+        });
+
+        $request = new \Bullet\Request('GET', '/badpath', array(), array('Host' => 'www.example.com'));
+        $result = $app->run($request);
+
+        $this->assertEquals(404, $result->status());
+        $this->assertEquals('Not Found', $result->content());
+    }
+
     public function testDefaultArrayToJSONContentConverter()
     {
         $app = new Bullet\App();


### PR DESCRIPTION
- Fixes #34
- Handlers now return 404 by default if unmatched (expected)
