### PR TITLE
HTTP 405 (Method Not Allowed) should include an Allow header

### DIFF
--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -307,7 +307,8 @@ class App extends \Pimple
                 self::$_pathLevel++;
                 $res = call_user_func($cb, $request);
             } else {
-                $res = $this->response(405);
+                $acceptMethods = array_keys($this->_callbacks['method'][self::$_pathLevel]);
+                $res = $this->response(405)->header('Allow', implode(',', $acceptMethods));
             }
         } else {
             // Empty out collected method callbacks

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -443,6 +443,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
         $response = $app->run('PUT', 'methodnotallowed');
         $this->assertEquals(405, $response->status());
+        $this->assertEquals('GET,POST', $response->header('Allow'));
     }
 
     public function testPathParamCaptureFirst()


### PR DESCRIPTION
Tiny change: Based on [the spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6), HTTP 405 responses should include an `Allow` header containing all the allowed methods for that path. Something similar is already implemented for `OPTIONS` requests, so I applied the same concept to 405 responses.
