### PR TITLE
Fixes bug where Bullet incorrectly removes more than just the extension ...

### DIFF
--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -171,7 +171,7 @@ class App extends Container
         $this->_requestPath = $this->_request->url();
 
         // Detect extension and assign it as the requested format (default is 'html')
-        $dotPos = strpos($this->_requestPath, '.');
+        $dotPos = strrpos($this->_requestPath, '.');
         if($dotPos !== false) {
             $ext = substr($this->_requestPath, $dotPos+1);
             $this->_request->format($ext);

--- a/src/Bullet/Request.php
+++ b/src/Bullet/Request.php
@@ -536,7 +536,7 @@ class Request
         }
 
         // Detect extension and assign it as the requested format (overrides 'Accept' header)
-        $dotPos = strpos($this->url(), '.');
+        $dotPos = strrpos($this->url(), '.');
         if($dotPos !== false) {
             $ext = substr($this->url(), $dotPos+1);
             $this->_format = $ext;


### PR DESCRIPTION
...from a param if the param contains multiple periods.

The problem is also mentioned here:
https://bitbucket.org/totha/scrum-poker/src/ed69fb88be9763d8efcd5378baa7546a2fc776da/web/poker.js#cl-4
