### PR TITLE
Give users more control over response handlers (fixes #68)

### DIFF
--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -59,7 +59,8 @@ class App extends Container
             function($response) {
                 $response->contentType('application/json');
                 $response->content(json_encode($response->content()));
-            }
+            },
+            'array-content'
         );
 
         // Pimple constructor
@@ -757,10 +758,11 @@ class App extends Container
      *
      * @param callable $condtion Function name or closure to test against response
      * @param callable $handler Function name or closure to modify response
+     * @param string $name Unique label for the new handler
      *
      * @returns \Bullet\App
      */
-    public function registerResponseHandler($condition, $handler)
+    public function registerResponseHandler($condition, $handler, $name = '')
     {
         if(null !== $condition && !is_callable($condition)) {
             throw new \InvalidArgumentException("First argument to " . __METHOD__ . " must be a valid callback or NULL. Given argument was neither.");
@@ -769,10 +771,16 @@ class App extends Container
             throw new \InvalidArgumentException("Second argument to " . __METHOD__ . " must be a valid callback. Given argument was not callable.");
         }
 
-        $this->_responseHandlers[] = array(
+        $handler = array(
             'condition' => $condition,
             'handler'   => $handler
         );
+
+        if (!$name) {
+            $this->_responseHandlers[] = $handler;
+        } else {
+            $this->_responseHandlers[$name] = $handler;
+        }
 
         return $this;
     }

--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -770,6 +770,9 @@ class App extends Container
         if(!is_callable($handler)) {
             throw new \InvalidArgumentException("Second argument to " . __METHOD__ . " must be a valid callback. Given argument was not callable.");
         }
+        if ($name && !is_string($name)) {
+            throw new \InvalidArgumentException("Third argument to " . __METHOD__ . " must be a string. Given argument was not a string.");
+        }
 
         $handler = array(
             'condition' => $condition,

--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -789,6 +789,17 @@ class App extends Container
     }
 
     /**
+     * Remove a previously-registered response handler
+     *
+     * @param mixed $name Response handler name or index
+     */
+    public function removeResponseHandler($name) {
+        if (isset($this->_responseHandlers[$name])) {
+            unset($this->_responseHandlers[$name]);
+        }
+    }
+
+    /**
      * Modify response to prepare it for returning.
      *
      * Applies special logic for particular response types and ensure response

--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -60,7 +60,7 @@ class App extends Container
                 $response->contentType('application/json');
                 $response->content(json_encode($response->content()));
             },
-            'array-content'
+            'array_json'
         );
 
         // Pimple constructor

--- a/src/Bullet/App.php
+++ b/src/Bullet/App.php
@@ -762,7 +762,7 @@ class App extends Container
      *
      * @returns \Bullet\App
      */
-    public function registerResponseHandler($condition, $handler, $name = '')
+    public function registerResponseHandler($condition, $handler, $name = null)
     {
         if(null !== $condition && !is_callable($condition)) {
             throw new \InvalidArgumentException("First argument to " . __METHOD__ . " must be a valid callback or NULL. Given argument was neither.");

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1208,6 +1208,68 @@ class AppTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testThatDefaultResponseHandlerMayBeRemoved()
+    {
+        $app = new Bullet\App();
+        $app->path('/', function($request) use($app) {
+            return ['a'];
+        });
+
+        $app->removeResponseHandler('array-content');
+
+        $request = new \Bullet\Request('GET', '/');
+        $result = $app->run($request);
+
+        $this->assertEquals(['a'], $result->content());
+    }
+
+    public function testThatUserResponseHandlersMayBeRemoved()
+    {
+        $app = new Bullet\App();
+        $app->path('/', function($request) use($app) {
+            return 'foo';
+        });
+        $request = new \Bullet\Request('GET', '/');
+
+        $app->registerResponseHandler(
+            function() { return true; },
+            function($response) {
+                $response->content('bar');
+            },
+            'foo'
+        );
+
+        $result = $app->run($request);
+        $this->assertEquals('bar', $result->content());
+
+        $app->removeResponseHandler('foo');
+        $result = $app->run($request);
+        $this->assertEquals('foo', $result->content());
+    }
+
+    public function testThatIndexedResponseHandlersMayBeRemoved()
+    {
+        $app = new Bullet\App();
+        $app->path('/', function($request) use($app) {
+            return 'foo';
+        });
+        $request = new \Bullet\Request('GET', '/');
+
+        $app->registerResponseHandler(
+            function() { return true; },
+            function($response) {
+                $response->content('bar');
+            }
+        );
+
+        $result = $app->run($request);
+        $this->assertEquals('bar', $result->content());
+
+        $app->removeResponseHandler(0);
+        $result = $app->run($request);
+        $this->assertEquals('foo', $result->content());
+    }
+
     public function testNestedRoutesInsideParamCallback()
     {
         $app = new Bullet\App();

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1184,7 +1184,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
                 $response->contentType('text/plain');
                 $response->content('this is not json');
             },
-            'array-content'
+            'array_json'
         );
 
         $request = new \Bullet\Request('GET', '/');
@@ -1215,7 +1215,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             return array('a');
         });
 
-        $app->removeResponseHandler('array-content');
+        $app->removeResponseHandler('array_json');
 
         $request = new \Bullet\Request('GET', '/');
         $result = $app->run($request);

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1169,6 +1169,31 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('abc', $result->content());
     }
 
+    public function testThatUserResponseHandlersOverrideDefaults()
+    {
+        $app = new Bullet\App();
+        $app->path('/', function($request) use($app) {
+            return ['a'];
+        });
+
+        $app->registerResponseHandler(
+            function($response) {
+                return is_array($response->content());
+            },
+            function($response) {
+                $response->contentType('text/plain');
+                $response->content('this is not json');
+            },
+            'array-content'
+        );
+
+        $request = new \Bullet\Request('GET', '/');
+        $result = $app->run($request);
+
+        $this->assertEquals('this is not json', $result->content());
+        $this->assertEquals('text/plain', $result->contentType());
+    }
+
     public function testNestedRoutesInsideParamCallback()
     {
         $app = new Bullet\App();

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1194,6 +1194,20 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('text/plain', $result->contentType());
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Third argument to Bullet\App::registerResponseHandler must be a string. Given argument was not a string.
+     */
+    public function testThatResponseHandlerNamesMustBeAString()
+    {
+        $app = new Bullet\App();
+        $app->registerResponseHandler(
+            function($response) { return true; },
+            function($response) {},
+            123
+        );
+    }
+
     public function testNestedRoutesInsideParamCallback()
     {
         $app = new Bullet\App();

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1173,7 +1173,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Bullet\App();
         $app->path('/', function($request) use($app) {
-            return ['a'];
+            return array('a');
         });
 
         $app->registerResponseHandler(
@@ -1212,7 +1212,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Bullet\App();
         $app->path('/', function($request) use($app) {
-            return ['a'];
+            return array('a');
         });
 
         $app->removeResponseHandler('array-content');
@@ -1220,7 +1220,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $request = new \Bullet\Request('GET', '/');
         $result = $app->run($request);
 
-        $this->assertEquals(['a'], $result->content());
+        $this->assertEquals(array('a'), $result->content());
     }
 
     public function testThatUserResponseHandlersMayBeRemoved()


### PR DESCRIPTION
- Adds optional response handler names
- Names the default array-to-JSON handler `array-content`
- Adds `removeResponseHandler`

Fixes vlucas/bulletphp#68