### PR TITLE
Impove use Bullet and TestCase namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "phpunit/phpunit": "~5.7"
     },
     "autoload": {
-        "psr-0": {
-            "Bullet": "src/"
+        "psr-4": {
+            "Bullet\\": "src/Bullet"
         }
     }
 }

--- a/src/Bullet/Request.php
+++ b/src/Bullet/Request.php
@@ -70,7 +70,7 @@ class Request
     public function __construct($method = null, $url = null, array $params = array(), array $headers = array(), $rawBody = null)
     {
         // Die magic_quotes, just die...
-        if(get_magic_quotes_gpc()) {
+        if(function_exists('get_magic_quotes_gpc') === false) {
             $stripslashes_gpc = function(&$value, $key) {
                 $value = stripslashes($value);
             };
@@ -705,7 +705,7 @@ class Request
 
     /**
      * Try to decode the raw request body as JSON and return it
-     * 
+     *
      * This method calls json_decode on raw() each time it's called,
      * so don't overindulge.
      */
@@ -834,12 +834,12 @@ class Request
             || $op != ''
             || strpos($ua, 'iphone') !== false
             || strpos($ua, 'android') !== false
-            || strpos($ua, 'iemobile') !== false 
+            || strpos($ua, 'iemobile') !== false
             || strpos($ua, 'kindle') !== false
-            || strpos($ua, 'sony') !== false 
-            || strpos($ua, 'symbian') !== false 
-            || strpos($ua, 'nokia') !== false 
-            || strpos($ua, 'samsung') !== false 
+            || strpos($ua, 'sony') !== false
+            || strpos($ua, 'symbian') !== false
+            || strpos($ua, 'nokia') !== false
+            || strpos($ua, 'samsung') !== false
             || strpos($ua, 'mobile') !== false
             || strpos($ua, 'windows ce') !== false
             || strpos($ua, 'epoc') !== false
@@ -942,7 +942,7 @@ class Request
 
     /**
      * Is this a Flash request?
-     * 
+     *
      * @return bool
      */
     public function isFlash()

--- a/tests/Bullet/Tests/AppTest.php
+++ b/tests/Bullet/Tests/AppTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Bullet\Tests;
-use Bullet;
+use Bullet\App;
 use Bullet\Request;
 use Bullet\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @backupGlobals disabled
  */
-class AppTest extends \PHPUnit_Framework_TestCase
+class AppTest extends TestCase
 {
     protected $backupGlobalsBlacklist = array('app');
 
@@ -15,7 +16,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function() use(&$collect) {
             $collect[] = 'test';
         });
@@ -28,7 +29,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleResourceGet()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->resource('test', function() {
             return 'resource';
         });
@@ -39,7 +40,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testMultiplePathsWithAray()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path(array('test', 'test2'), function() use($app) {
             return "test";
         });
@@ -53,7 +54,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             $collect[] = 'test';
             $app->path('foo', function() use(&$collect) {
@@ -74,7 +75,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             $app->path('foo', function() use(&$collect) {
                 return 'foo';
@@ -95,7 +96,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             $app->path('foo', function() use(&$collect) {
                 return 'foo';
@@ -114,7 +115,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function test204HasNoBodyContent()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test-no-content', function($request) use($app) {
             $app->get(function($request) {
                 return 204;
@@ -130,7 +131,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             $collect[] = 'test';
             $app->path('foo', function() use($app, &$collect) {
@@ -154,7 +155,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app, &$collect) {
             $collect[] = 'root';
         });
@@ -170,7 +171,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testExactPathMatchNotInParamCapture()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/ping', function($request) use($app) {
             $app->param('slug', function($request, $slug) use($app) {
                 return $slug;
@@ -185,7 +186,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testRepeatPathnameNested()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/about/', function($request) use ($app) {
             // return data for my "about" path
             return 'about';
@@ -204,7 +205,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testRepeatPathnameNestedPathInsideParam()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/about/', function($request) use ($app) {
             // return data for my "about" path
             return 'about';
@@ -227,7 +228,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testGetHandlerBeforeParamCapture()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/ping', function($request) use($app) {
             $app->get(function($request) use($app) {
                 return "pong";
@@ -246,7 +247,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testParamCallbacksGetClearedAfterMatch()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('about', function() use ($app){
             $page = 'about';
             $app->get(function() use ($app,$page){
@@ -270,7 +271,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testDoubleSlugMethodHandler()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/ping', function($request) use($app) {
             $app->get(function($request) use($app) {
                 return "pong";
@@ -297,7 +298,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/match/', function($request) use($app, &$collect) {
             $collect[] = 'matched';
             $app->path('/me/', function($request) use($app, &$collect) {
@@ -316,7 +317,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHelperIsRequestPathReturnsTrueWhenPathIsCurrent()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             return var_export($app->isRequestPath(), true);
         });
@@ -329,7 +330,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $actual = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('foo', function($request) use($app, &$actual) {
             // Should be 'false' - "foo" is not the full requested path, "foo/bar" is
             $actual[] = var_export($app->isRequestPath(), true);
@@ -347,7 +348,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $collect = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$collect) {
             return 'test';
         });
@@ -360,7 +361,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testOnlyLastMatchedCallbackIsReturned()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->path('teapot', function($request) use($app) {
                 // GET
@@ -385,7 +386,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $actual = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$actual) {
             $app->path('teapot', function($request) use($app, &$actual) {
                 // Should be executed
@@ -408,7 +409,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $actual = array();
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app, &$actual) {
             $app->path('method', function($request) use($app, &$actual) {
                 // Should not be executed (not POST)
@@ -429,7 +430,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testIfPathExistsAndMethodCallbackDoesNotResponseIs405()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('methodnotallowed', function($request) use($app) {
             // GET
             $app->get(function($request) use($app) {
@@ -448,7 +449,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathParamCaptureFirst()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('paramtest', function($request) use($app) {
             // Digit
             $app->param('ctype_digit', function($request, $id) use($app) {
@@ -467,7 +468,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathParamCaptureSecond()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('paramtest', function($request) use($app) {
             // Digit
             $app->param('ctype_digit', function($request, $id) use($app) {
@@ -486,7 +487,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathParamCaptureWithMethodHandlers()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('paramtest', function($request) use($app) {
             // Digit
             $app->param('int', function($request, $id) use($app) {
@@ -514,7 +515,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHandlersCanReturnIntergerAsHttpStatus()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testint', function() use($app) {
             return 200;
         });
@@ -526,7 +527,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHandlersCanReturnIntergerAsHttpStatusInMethodCallback()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testint2', function() use($app) {
             // GET
             $app->get(function($request) use($app) {
@@ -541,7 +542,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomHttpStatusHandler()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testhandler', function() use($app) {
             // GET
             $app->get(function($request) use($app) {
@@ -561,7 +562,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomHttpStatusHandlerKeepingContent()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testhandler', function() use($app) {
             // GET
             $app->get(function($request) use($app) {
@@ -581,7 +582,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathExecutionIgnoresExtension()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -596,7 +597,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathWithExtensionExecutesMatchingFormatHandler()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -616,7 +617,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testPathWithExtensionAndFormatHandlersButNoMatchingFormatHandlerReturns406()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->path('foo', function() use($app) {
                 $app->format('json', function() use($app) {
@@ -635,7 +636,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatHanldersRunUsingAcceptHeader()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('posts', function($request) use($app) {
             $app->get(function() use($app) {
                 $app->format('json', function() use($app) {
@@ -649,7 +650,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new Bullet\Request('POST', 'posts', array(), array('Accept' => 'application/json'));
+        $request = new Request('POST', 'posts', array(), array('Accept' => 'application/json'));
         $response = $app->run($request);
         $this->assertEquals(201, $response->status());
         $this->assertEquals('{"created":"something"}', $response->content());
@@ -657,7 +658,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testNestedRun()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('foo', function($request) use($app) {
             return "foo";
         });
@@ -672,7 +673,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsCurrentPathWhenCalledWithNoArguments()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -687,7 +688,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsRelativePath()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -702,7 +703,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsRelativePathWithoutRepeating()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -717,7 +718,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsRelativePathWithoutRepeatingLastPortion()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->path('foo', function() use($app) {
                 return $app->url('./foo'); // Should not be 'test/foo/foo'
@@ -731,7 +732,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsRelativePathWithoutRepeatingBasePath()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('events', function($request) use($app) {
             return $app->url('./events/42'); // Should not be 'events/events/42' or just 'events'
         });
@@ -743,7 +744,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlHelperReturnsGivenPath()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $collect[] = 'test';
             $app->path('foo', function() use($app) {
@@ -761,7 +762,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testStatusOnResponseObjectReturnsCorrectStatus()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('posts', function($request) use($app) {
             $app->post(function() use($app) {
                 return $app->response(201, 'Created something!');
@@ -774,7 +775,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testStatusOnResponseObjectReturnsCorrectStatusAsJSON()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('posts', function($request) use($app) {
             $app->post(function() use($app) {
                 $app->format('json', function() use($app) {
@@ -789,7 +790,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionsAreCaughtWhenCustomHandlerIsRegistered()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->on('Exception', function(Request $request, Response $response, \Exception $e) {
             if($e instanceof \Exception) {
                 $response->content('yep');
@@ -808,7 +809,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionHandlerAllowsStatusOtherThan500()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->on('InvalidArgumentException', function(Request $request, Response $response, \Exception $e) {
             $response->status(200)->content('There is a pankake on my head. Your argument is invalid.');
         });
@@ -823,7 +824,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testEventHandlerBefore()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testhandler', function() use($app) {
             $app->post(function($request) use($app) {
                 return $request->foo;
@@ -841,7 +842,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testEventHandlerAfter()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('testhandler', function() use($app) {
             $app->put(function($request) use($app) {
                 return 'test';
@@ -859,7 +860,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHelperLoading()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->helper('test', __NAMESPACE__ . '\TestHelper');
         $testHelper = $app->helper('test');
 
@@ -868,14 +869,14 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHelperThrowsExceptionForUnregisteredHelpers()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $this->setExpectedException('InvalidArgumentException');
         $testHelper = $app->helper('nonexistent');
     }
 
     public function testSupportsPatch()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('update', function($request) use($app) {
             $app->patch(function($request) {
                 return $request->params();
@@ -883,7 +884,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         });
 
         $params = array('foo' => 'bar', 'bar' => 'baz');
-        $request = new \Bullet\Request('PATCH', '/update', $params);
+        $request = new Request('PATCH', '/update', $params);
         $result = $app->run($request);
 
         $this->assertEquals('PATCH', $request->method());
@@ -892,14 +893,14 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportsHeadAsGetWithNoResponseBody()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('someroute', function($request) use($app) {
             $app->get(function($request) {
                 return 'I am hidden with a HEAD request!';
             });
         });
 
-        $request = new \Bullet\Request('HEAD', '/someroute');
+        $request = new Request('HEAD', '/someroute');
         $result = $app->run($request);
 
         $this->assertEquals('HEAD', $request->method());
@@ -908,7 +909,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportsHeadWithHandler()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->head(function($request) use($app) {
                 return $app->response()->header('X-Special', 'Stuff');
@@ -918,7 +919,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('HEAD', '/test');
+        $request = new Request('HEAD', '/test');
         $response = $app->run($request);
         $this->assertEquals('HEAD', $request->method());
         $this->assertEquals('Stuff', $response->header('X-Special'));
@@ -927,7 +928,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportCustomHeaders()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->get(function($request) use($app) {
                 return $app->response()
@@ -937,7 +938,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/test');
+        $request = new Request('GET', '/test');
         $response = $app->run($request);
         $this->assertEquals('GET', $request->method());
         $this->assertEquals('Stuff', $response->header('X-Special'));
@@ -946,7 +947,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSubdomainRoute()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->subdomain('test', function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -955,7 +956,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'test.bulletphp.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'test.bulletphp.com'));
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -964,7 +965,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSubdomainRouteAfterMethodHandler()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->get(function($request) {
             return "GET main path";
         });
@@ -976,7 +977,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'bar.bulletphp.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'bar.bulletphp.com'));
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -985,7 +986,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSubdomainRouteWithPathsWithNoRequestSubdomain()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->subdomain('bar', function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -999,7 +1000,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -1008,7 +1009,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSubdomainRouteArray()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->subdomain(array('www', false), function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -1017,7 +1018,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'www.bulletphp.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'www.bulletphp.com'));
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -1026,7 +1027,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testSubdomainFalseRouteWithNoSubdomain()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->subdomain(false, function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -1035,7 +1036,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'bulletphp.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'bulletphp.com'));
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -1044,7 +1045,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testDomainRoute()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->domain('example.com', function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -1053,7 +1054,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'www.example.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'www.example.com'));
         $result = $app->run($request);
 
         $this->assertEquals(200, $result->status());
@@ -1062,7 +1063,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testDomainRoute404()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->domain('example.com', function($request) use($app) {
             $app->path('/', function($request) use($app) {
                 $app->get(function($request) {
@@ -1071,7 +1072,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/', array(), array('Host' => 'www.example2.com'));
+        $request = new Request('GET', '/', array(), array('Host' => 'www.example2.com'));
         $result = $app->run($request);
 
         $this->assertEquals(404, $result->status());
@@ -1079,7 +1080,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testDomainRoute404OnRequestedDomain()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->domain('example.com', function($request) use($app) {
             $app->path('/goodpath', function($request) use($app) {
                 $app->get(function($request) {
@@ -1088,7 +1089,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', '/badpath', array(), array('Host' => 'www.example.com'));
+        $request = new Request('GET', '/badpath', array(), array('Host' => 'www.example.com'));
         $result = $app->run($request);
 
         $this->assertEquals(404, $result->status());
@@ -1097,12 +1098,12 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultArrayToJSONContentConverter()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return array('foo' => 'bar');
         });
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals(json_encode(array('foo' => 'bar')), $result->content());
@@ -1111,12 +1112,12 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testResponseWithNoContentConverterIsUnchanged()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return 'foobar';
         });
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals('foobar', $result->content());
@@ -1125,7 +1126,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testResponseOfSpecificClassGetsConverted()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return new TestHelper();
         });
@@ -1140,7 +1141,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals('something', $result->content());
@@ -1149,7 +1150,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testThatAllApplicableResponseHandlersAreApplied()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return 'a';
         });
@@ -1182,7 +1183,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals('abc', $result->content());
@@ -1190,7 +1191,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testThatUserResponseHandlersOverrideDefaults()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return array('a');
         });
@@ -1206,7 +1207,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             'array_json'
         );
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals('this is not json', $result->content());
@@ -1219,7 +1220,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatResponseHandlerNamesMustBeAString()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->registerResponseHandler(
             function($response) { return true; },
             function($response) {},
@@ -1229,14 +1230,14 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testThatDefaultResponseHandlerMayBeRemoved()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return array('a');
         });
 
         $app->removeResponseHandler('array_json');
 
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
         $result = $app->run($request);
 
         $this->assertEquals(array('a'), $result->content());
@@ -1244,11 +1245,11 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testThatUserResponseHandlersMayBeRemoved()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return 'foo';
         });
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
 
         $app->registerResponseHandler(
             function() { return true; },
@@ -1268,11 +1269,11 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testThatIndexedResponseHandlersMayBeRemoved()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('/', function($request) use($app) {
             return 'foo';
         });
-        $request = new \Bullet\Request('GET', '/');
+        $request = new Request('GET', '/');
 
         $app->registerResponseHandler(
             function() { return true; },
@@ -1291,7 +1292,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testNestedRoutesInsideParamCallback()
     {
-        $app = new Bullet\App();
+        $app = new App();
 
         $app->path('admin', function($request) use($app) {
             $app->path('client', function($request) use($app) {
@@ -1313,7 +1314,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHMVCNestedRouting()
     {
-        $app = new Bullet\App();
+        $app = new App();
 
         $app->path('a', function($request) use($app) {
             $app->path('b', function($request) use($app) {
@@ -1336,7 +1337,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testHMVCNestedRoutingWithSubdomain()
     {
-        $app = new Bullet\App();
+        $app = new App();
 
         $app->subdomain('test', function($request) use($app) {
             $app->path('a', function($request) use($app) {
@@ -1348,7 +1349,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             $app->path('c', function($request) use($app) {
                 $app->path('a', function($request) use($app) {
                     $app->path('b', function($request) use($app) {
-                        $request = new \Bullet\Request('GET', 'a/b', array(), array('Host' => 'test.bulletphp.com'));
+                        $request = new Request('GET', 'a/b', array(), array('Host' => 'test.bulletphp.com'));
                         $a = $app->run($request);
                         return $a->content() . " + c/a/b";
                     });
@@ -1356,14 +1357,14 @@ class AppTest extends \PHPUnit_Framework_TestCase
             });
         });
 
-        $request = new \Bullet\Request('GET', 'c/a/b', array(), array('Host' => 'test.bulletphp.com'));
+        $request = new Request('GET', 'c/a/b', array(), array('Host' => 'test.bulletphp.com'));
         $result = $app->run($request);
         $this->assertEquals('a/b + c/a/b', $result->content());
     }
 
     public function testClosureBinding()
     {
-        $app = new Bullet\App();
+        $app = new App();
 
         $app->path('closure-binding', function($request) {
             return $this->url('/worked/');

--- a/tests/Bullet/Tests/ChunkedResponseTest.php
+++ b/tests/Bullet/Tests/ChunkedResponseTest.php
@@ -1,16 +1,19 @@
 <?php
 namespace Bullet\Tests;
+use Bullet\App;
+use Bullet\Response\Chunked;
+use PHPUnit\Framework\TestCase;
 
-class ChunkedTest extends \PHPUnit_Framework_TestCase
+class ChunkedTest extends TestCase
 {
     private $_testContent = [
         "The", " ", "quick", " brown", " fox ", "jumps", " over ", "the ",
         "lazy ", "dog."
     ];
     private function _runTestBulletApp($chunkSize, $content) {
-        $app = new \Bullet\App();
+        $app = new App();
         $app->path('/test', function($request) use ($chunkSize, $content) {
-            $c = new \Bullet\Response\Chunked($content);
+            $c = new Chunked($content);
             $c->chunkSize = $chunkSize;
             return $c;
         });

--- a/tests/Bullet/Tests/RequestTest.php
+++ b/tests/Bullet/Tests/RequestTest.php
@@ -1,42 +1,44 @@
 <?php
 namespace Bullet\Tests;
-use Bullet;
+use Bullet\App;
+use Bullet\Request;
+use PHPUnit\Framework\TestCase;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     function testMethod()
     {
-        $r = new Bullet\Request('POST', '/foo/bar');
+        $r = new Request('POST', '/foo/bar');
         $this->assertEquals('POST', $r->method());
     }
 
     function testMethodSupportsPatch()
     {
-        $r = new Bullet\Request('PATCH', '/foo/bar');
+        $r = new Request('PATCH', '/foo/bar');
         $this->assertEquals('PATCH', $r->method());
     }
 
     function testUrl()
     {
-        $r = new Bullet\Request('DELETE', '/foo/bar/');
+        $r = new Request('DELETE', '/foo/bar/');
         $this->assertEquals('/foo/bar/', $r->url());
     }
 
     function testFormatDefaultsToNull()
     {
-        $r = new Bullet\Request('DELETE', '/foo/bar/');
+        $r = new Request('DELETE', '/foo/bar/');
         $this->assertEquals(null, $r->format());
     }
 
     function testExtensionOverridesAcceptHeader()
     {
-        $r = new Bullet\Request('PUT', '/users/42.xml', array(), array('Accept' => 'text/html,application/json'));
+        $r = new Request('PUT', '/users/42.xml', array(), array('Accept' => 'text/html,application/json'));
         $this->assertEquals('xml', $r->format());
     }
 
     function testAccept()
     {
-        $r = new Bullet\Request('', '', array(), array('Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json'));
+        $r = new Request('', '', array(), array('Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json'));
         $this->assertTrue($r->accept('html'));
         $this->assertTrue($r->accept('xhtml'));
         $this->assertTrue($r->accept('xml'));
@@ -46,7 +48,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testAcceptHeader()
     {
-        $r = new Bullet\Request('', '', array(), array('Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json'));
+        $r = new Request('', '', array(), array('Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json'));
         $this->assertEquals(array(
           "text/html" => "text/html",
           "application/xhtml+xml" => "application/xhtml+xml",
@@ -58,9 +60,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testAcceptHeaderOverridesDefaultHtmlInApp()
     {
-        $app = new Bullet\App();
+        $app = new App();
         // Accept only JSON and request URL with no extension
-        $req = new Bullet\Request('PUT', '/foo', array(), array('Accept' => 'application/json'));
+        $req = new Request('PUT', '/foo', array(), array('Accept' => 'application/json'));
         $app->path('foo', function($request) use($app) {
             $app->format('json', function($request) {
                 return array('foo' => 'bar');
@@ -77,9 +79,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testAcceptAnyReturnsFirstFormat()
     {
-        $app = new Bullet\App();
+        $app = new App();
         // Accept only JSON and request URL with no extension
-        $req = new Bullet\Request('GET', '/foo', array(), array('Accept' => '*/*'));
+        $req = new Request('GET', '/foo', array(), array('Accept' => '*/*'));
         $app->path('foo', function($request) use($app) {
             $app->format('json', function($request) {
                 return array('foo' => 'bar');
@@ -96,9 +98,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testAcceptEmptyReturnsFirstFormat()
     {
-        $app = new Bullet\App();
+        $app = new App();
         // Accept only JSON and request URL with no extension
-        $req = new Bullet\Request('GET', '/foo', array());
+        $req = new Request('GET', '/foo', array());
         $app->path('foo', function($request) use($app) {
             $app->format('json', function($request) {
                 return array('foo' => 'bar');
@@ -111,32 +113,32 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testRawUrlencodedBodyIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/123.json', array(), array('Accept' => 'application/json'), 'id=123&foo=bar&bar=bar+baz');
+        $r = new Request('PUT', '/users/123.json', array(), array('Accept' => 'application/json'), 'id=123&foo=bar&bar=bar+baz');
         $this->assertEquals('123', $r->id);
         $this->assertEquals('bar baz', $r->bar);
     }
 
     function testRawJsonBodyIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"id":"123"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"id":"123"}');
         $this->assertEquals('123', $r->id);
     }
 
     function testRawJsonBodyIsDecodedInPostRequest()
     {
-        $r = new Bullet\Request('POST', '/users/129.json', array(), array('Accept' => 'application/json'), '{"id":"124"}');
+        $r = new Request('POST', '/users/129.json', array(), array('Accept' => 'application/json'), '{"id":"124"}');
         $this->assertEquals('124', $r->id);
     }
 
     function testRawJsonBodyIsIgnoredInPostRequestIfPostParamsAreSet()
     {
-        $r = new Bullet\Request('POST', '/users/129.json', array('id' => '123'), array('Accept' => 'application/json'), '{"id":"124"}');
+        $r = new Request('POST', '/users/129.json', array('id' => '123'), array('Accept' => 'application/json'), '{"id":"124"}');
         $this->assertEquals('123', $r->id);
     }
 
     function testGetWithParamsAreSetInQuerystringData()
     {
-        $r = new Bullet\Request('GET', '/users/129.json', array('id' => '124', 'foo' => 'bar'));
+        $r = new Request('GET', '/users/129.json', array('id' => '124', 'foo' => 'bar'));
         $this->assertEquals('124', $r->query('id'));
         $this->assertEquals('bar', $r->query('foo'));
         $this->assertEquals(array('id' => '124', 'foo' => 'bar'), $r->query());
@@ -144,51 +146,51 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testPostWithParamsAreSetInPostData()
     {
-        $r = new Bullet\Request('POST', '/users/129.json', array('id' => '124', 'foo' => 'bar'));
+        $r = new Request('POST', '/users/129.json', array('id' => '124', 'foo' => 'bar'));
         $this->assertEquals('124', $r->post('id'));
         $this->assertEquals('bar', $r->post('foo'));
     }
 
     function testRawJsonBodyWithSpacesInValueIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo":"bar baz"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo":"bar baz"}');
         $this->assertEquals('bar baz', $r->foo);
     }
 
     function testRawJsonBodyWithSpacesInKeyIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"baz"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"baz"}');
         $this->assertEquals('baz', $r->{'foo bar'});
     }
 
     function testRawJsonBodyWithSpacesInKeyAndValueIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"bar baz"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"foo bar":"bar baz"}');
         $this->assertEquals('bar baz', $r->{'foo bar'});
     }
 
     function testRawJsonBodyWithDotsInValueIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"link":"http://bulletphp.com/"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"link":"http://bulletphp.com/"}');
         $this->assertEquals('http://bulletphp.com/', $r->link);
     }
 
     function testRawJsonBodyWithDotsInKeyIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"bulletphp"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"bulletphp"}');
         $this->assertEquals('bulletphp', $r->{'the.link'});
     }
 
     function testRawJsonBodyWithDotsInKeyAndValueIsDecodedInPutRequest()
     {
-        $r = new Bullet\Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"http://bulletphp.com"}');
+        $r = new Request('PUT', '/users/42.json', array(), array('Accept' => 'application/json'), '{"the.link":"http://bulletphp.com"}');
         $this->assertEquals('http://bulletphp.com', $r->{'the.link'});
     }
 
     function testRawJsonBodyIsDecodedWithBadJSON()
     {
-        $r = new Bullet\Request('PUT', '/test', array(), array('Content-Type' => 'application/json'), '{\"title\":\"Updated New Post Title\",\"body\":\"<p>A much better post body</p>\"}\n');
-        $app = new Bullet\App();
+        $r = new Request('PUT', '/test', array(), array('Content-Type' => 'application/json'), '{\"title\":\"Updated New Post Title\",\"body\":\"<p>A much better post body</p>\"}\n');
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->put(function($request) {
                 return 'title: ' . $request->get('title');
@@ -200,20 +202,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testSubdomainCapture()
     {
-        $r = new Bullet\Request('GET', '/', array(), array('Host' => 'test.bulletphp.com'));
+        $r = new Request('GET', '/', array(), array('Host' => 'test.bulletphp.com'));
         $this->assertEquals('test', $r->subdomain());
     }
 
     function testSubdomainCaptureWithNoSubdomain()
     {
-        $r = new Bullet\Request('GET', '/', array(), array('Host' => 'bulletphp.com'));
+        $r = new Request('GET', '/', array(), array('Host' => 'bulletphp.com'));
         $this->assertFalse($r->subdomain());
     }
 
     function testOptionsHeader()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('OPTIONS', '/test');
+        $app = new App();
+        $req = new Request('OPTIONS', '/test');
         $app->path('test', function($request) use($app) {
             $app->get(function($request) {
                 return 'GET';
@@ -229,8 +231,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testOptionsHeaderForParamPaths()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('OPTIONS', '/test/this_is_a_slug');
+        $app = new App();
+        $req = new Request('OPTIONS', '/test/this_is_a_slug');
         $app->path('test', function($request) use($app) {
             $app->param('slug', function($request, $param) use ($app) {
                 $app->get(function($request) {
@@ -248,8 +250,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testOptionsHeaderWithCustomOptionsRoute()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('OPTIONS', '/test');
+        $app = new App();
+        $req = new Request('OPTIONS', '/test');
         $app->path('test', function($request) use($app) {
             $app->get(function($request) {
                 return 'GET';
@@ -268,8 +270,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testCacheHeaderFalse()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('GET', '/cache');
+        $app = new App();
+        $req = new Request('GET', '/cache');
         $app->path('cache', function($request) use($app) {
             $app->get(function($request) use($app) {
                 return $app->response(200, 'CONTENT')->cache(false);
@@ -282,8 +284,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testCacheHeaderTime()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('GET', '/cache');
+        $app = new App();
+        $req = new Request('GET', '/cache');
         $currentTime = time();
         $cacheTime = strtotime('+1 hour', $currentTime);
         $app->path('cache', function($request) use($app, $cacheTime) {
@@ -299,8 +301,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testCacheWithDateTimeObject()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('GET', '/cache');
+        $app = new App();
+        $req = new Request('GET', '/cache');
         $currentTime = time();
         $cacheTime = new \DateTime('+1 hour');
         $app->path('cache', function($request) use($app, $cacheTime) {
@@ -316,8 +318,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testCacheWithString()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('GET', '/cache');
+        $app = new App();
+        $req = new Request('GET', '/cache');
         $currentTime = time();
         $cacheTime = '1 hour';
         $app->path('cache', function($request) use($app, $cacheTime) {
@@ -333,8 +335,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testCacheWithSeconds()
     {
-        $app = new Bullet\App();
-        $req = new Bullet\Request('GET', '/cache');
+        $app = new App();
+        $req = new Request('GET', '/cache');
         $currentTime = time();
         $cacheTime = 3600;
         $app->path('cache', function($request) use($app, $cacheTime) {
@@ -350,27 +352,27 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     function testGetWithQueryString()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function($request) use($app) {
             $app->get(function($request) {
                 return 'foo=' . $request->foo;
             });
         });
-        $req = new Bullet\Request('GET', '/test?foo=bar');
+        $req = new Request('GET', '/test?foo=bar');
         $res = $app->run($req);
         $this->assertEquals('foo=bar', $res->content());
     }
 
     public function testRequestsDoNotShareParams()
     {
-        $first_request  = new Bullet\Request('GET', '/', array('foo' => 'bar'));
-        $second_request = new Bullet\Request('GET', '/', array());
+        $first_request  = new Request('GET', '/', array('foo' => 'bar'));
+        $second_request = new Request('GET', '/', array());
         $this->assertNull($second_request->foo);
     }
 
     public function testRequestIpClientId()
     {
-        $req = new Bullet\Request();
+        $req = new Request();
 
         unset($_SERVER['REMOTE_ADDR']);
         unset($_SERVER['HTTP_X_FORWARDED_FOR']);
@@ -381,7 +383,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testRequestIpForwardedFor()
     {
-        $req = new Bullet\Request();
+        $req = new Request();
 
         unset($_SERVER['HTTP_CLIENT_IP']);
         unset($_SERVER['REMOTE_ADDR']);
@@ -392,7 +394,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testRequestIpRemoteAddr()
     {
-        $req = new Bullet\Request();
+        $req = new Request();
 
         unset($_SERVER['HTTP_CLIENT_IP']);
         unset($_SERVER['HTTP_X_FORWARDED_FOR']);

--- a/tests/Bullet/Tests/ResponseTest.php
+++ b/tests/Bullet/Tests/ResponseTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Bullet\Tests;
-use Bullet;
+use Bullet\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for \Bullet\Response.
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     /**
      * @var \Bullet\Response Subject under test
@@ -17,7 +18,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->response = new Bullet\Response();
+        $this->response = new Response();
     }
 
     /**

--- a/tests/Bullet/Tests/SseResponseTest.php
+++ b/tests/Bullet/Tests/SseResponseTest.php
@@ -1,7 +1,10 @@
 <?php
 namespace Bullet\Tests;
+use Bullet\App;
+use Bullet\Response\Sse;
+use PHPUnit\Framework\TestCase;
 
-class SseResponseTest extends \PHPUnit_Framework_TestCase
+class SseResponseTest extends TestCase
 {
     private $_testContent = [
         [
@@ -15,9 +18,9 @@ class SseResponseTest extends \PHPUnit_Framework_TestCase
 
     private function _runTestBulletApp($content)
     {
-        $app = new \Bullet\App();
+        $app = new App();
         $app->path('/test', function($request) use ($content) {
-            return new \Bullet\Response\Sse($content);
+            return new Sse($content);
         });
         $response = $app->run('GET', '/test');
         $this->assertInstanceOf('\Bullet\\Response\\Sse', $response);

--- a/tests/Bullet/Tests/View/BlockTest.php
+++ b/tests/Bullet/Tests/View/BlockTest.php
@@ -1,11 +1,11 @@
 <?php
 namespace Bullet\Tests\View;
-use Bullet;
 use Bullet\View\Template;
+use PHPUnit\Framework\TestCase;
 
-class BlockTest extends \PHPUnit_Framework_TestCase
+class BlockTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->templateDir = dirname(dirname(dirname(__DIR__))) . '/fixtures/templates/';
 
@@ -18,7 +18,7 @@ class BlockTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // Restore config to original state
         Template::config($this->oldConfig);
@@ -50,12 +50,12 @@ class BlockTest extends \PHPUnit_Framework_TestCase
     {
         $tpl = new Template('test');
         $tpl->layout('layouts/block');
-        $block = $tpl->block('js')->content(function() { })
+        $tpl->block('js')->content(function() { })
             ->append(function() { echo 'Content'; });
         $this->assertEquals("Content<div><p>Test</p></div>", $tpl->content());
     }
 
-    public function testBlockPreppend()
+    public function testBlockPrepend()
     {
         $tpl = new Template('block');
         $block = $tpl->block(__FUNCTION__)->prepend(function() { echo "Test"; });
@@ -74,7 +74,7 @@ class BlockTest extends \PHPUnit_Framework_TestCase
     {
         $tpl = new Template('test');
         $tpl->layout('layouts/block');
-        $block = $tpl->block('js')->content(function() { })
+        $tpl->block('js')->content(function() { })
             ->prepend(function() { echo 'Content'; });
         $this->assertEquals("Content<div><p>Test</p></div>", $tpl->content());
     }

--- a/tests/Bullet/Tests/View/TemplateTest.php
+++ b/tests/Bullet/Tests/View/TemplateTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace Bullet\Tests\View;
-use Bullet;
+use Bullet\App;
+use Bullet\Request;
+use Bullet\Response;
 use Bullet\View\Template;
+use PHPUnit\Framework\TestCase;
 
-class TemplateTest extends \PHPUnit_Framework_TestCase
+class TemplateTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->templateDir = dirname(dirname(dirname(__DIR__))) . '/fixtures/templates/';
 
@@ -18,7 +21,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         // Restore config to original state
         Template::config($this->oldConfig);
@@ -96,7 +99,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
 
     public function testTemplateHelperReturnsTemplateObjectInstance()
     {
-        $app = new Bullet\App(array(
+        $app = new App(array(
             'template.cfg' => array('path' => $this->templateDir)
         ));
         $app->path('template-test', function($request) use($app) {
@@ -132,7 +135,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownInTemplate()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('test', function() use($app) {
             return $app->template('exception');
         });
@@ -148,7 +151,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
 
     public function testTemplateDoesNotDoubleRender()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('renderCount', function($request) use($app) {
             return $app->template('renderCount');
         });
@@ -159,7 +162,7 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
 
     public function testTemplateRenderCacheCanBeCleared()
     {
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('renderCount', function($request) use($app) {
             $tpl = $app->template('renderCount');
             $rendered = $tpl->content();
@@ -174,12 +177,12 @@ class TemplateTest extends \PHPUnit_Framework_TestCase
     {
         Template::config(array('path_layouts' => $this->templateDir . 'layouts/'));
 
-        $app = new Bullet\App();
+        $app = new App();
         $app->path('variableSet', function($request) use($app) {
             return $app->template('variableSet', array('variable' => 'one'))
                 ->layout('div');
         });
-        $app->on('beforeResponseHandler', function(\Bullet\Request $request, \Bullet\Response $response, $rawResponse) use($app) {
+        $app->on('beforeResponseHandler', function(Request $request, Response $response, $rawResponse) use($app) {
             $rawResponse->set('variable', 'two')->layout(false);
         });
         $res = $app->run('GET', '/variableSet/');


### PR DESCRIPTION
# Changed log
- Add `php-7.2`, `php-7.3` and `php-7.4` version tests during Travis CI build.
- Since the `php-7.x` versions are released, the `hhvm` support should be removed.
- To support future PHPUnit versions, it's good to use `PHPUnit\Framework\TestCase` namespace.
- The `PSR-0` autoloading is deprecated and using `PSR-4` autoloading instead.
- Let all class instances use `use` syntax to define class with namespace on the head of PHP files.
- Removing additional whitesapces.
- The `get_magic_quotes_gpc` function is deprecated since `php-7.4` version. And it should use the `function_exists` to check `get_magic_quotes_gpc` is existed inside `if` condition.